### PR TITLE
chore: bump version to 0.1.38

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remux",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remux",
-      "version": "0.1.37",
+      "version": "0.1.38",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remux",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "description": "Remote tmux web client — monitor and control terminal sessions from any device",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- bump the package version from 0.1.37 to 0.1.38 after merging #19 into dev
- keep the release metadata aligned with the repository patch-bump rule for merged feature work

## Testing
- not run (version metadata only)