### PR TITLE
feat: DevTunnel, snapfeed feedback, bandwidth stats, Gastown, Go TUI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,14 @@
       "version": "0.1.54",
       "license": "MIT",
       "dependencies": {
+        "@microsoft/snapfeed": "^0.1.0",
+        "@microsoft/snapfeed-server": "^0.1.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-serialize": "^0.14.0",
         "@xterm/headless": "^6.0.0",
         "@xterm/xterm": "^6.0.0",
         "express": "^5.2.1",
+        "html2canvas": "^1.4.1",
         "node-pty": "^1.0.0",
         "qrcode-terminal": "^0.12.0",
         "react": "^19.2.4",
@@ -190,7 +193,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -239,7 +241,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -738,12 +739,70 @@
         }
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@microsoft/snapfeed": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/snapfeed/-/snapfeed-0.1.0.tgz",
+      "integrity": "sha512-uLQInxBkfCi9uJVu0gSKed+Qj3/DHApDtwKM9d1HLDF1Nx246wBNkK4MOGaaGgLP7ZcWfQCr38odMvG3Tzduxw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "html2canvas": "^1.4.0"
+      },
+      "peerDependenciesMeta": {
+        "html2canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@microsoft/snapfeed-server": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/snapfeed-server/-/snapfeed-server-0.1.0.tgz",
+      "integrity": "sha512-ee5IsanrK3ewFzmikmABRSl92Bt1D34DNNIJrY/K1kt+xx6qU0eX2sJFsaEnB7GFD3tL6bPSO0gBNWwN+XkAVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.13.0",
+        "better-sqlite3": "^11.0.0",
+        "hono": "^4.6.0"
+      },
+      "bin": {
+        "snapfeed-server": "dist/cli.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@microsoft/snapfeed": "^0.1.0",
+        "express": "^4.0.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/snapfeed": {
+          "optional": true
+        },
+        "express": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.1",
@@ -1183,7 +1242,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1497,6 +1555,46 @@
         "node": ">=12"
       }
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -1505,6 +1603,26 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/bn.js": {
@@ -1535,6 +1653,30 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -1620,6 +1762,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/cliui": {
       "version": "9.0.1",
@@ -1834,6 +1982,15 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/css-tree": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
@@ -1893,6 +2050,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1906,7 +2087,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -1954,6 +2134,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/entities": {
@@ -2082,6 +2271,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -2153,6 +2351,12 @@
         }
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -2191,6 +2395,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -2287,6 +2497,12 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2333,6 +2549,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -2344,6 +2569,19 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/http_ece": {
@@ -2404,10 +2642,36 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -2448,7 +2712,6 @@
       "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.0.1",
         "@asamuzakjp/dom-selector": "^7.0.3",
@@ -2848,6 +3111,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -2862,6 +3137,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -2888,6 +3169,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -2895,6 +3182,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-addon-api": {
@@ -3009,7 +3308,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3078,6 +3376,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -3089,6 +3414,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -3148,12 +3483,26 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3168,6 +3517,20 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/require-directory": {
@@ -3312,6 +3675,18 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
@@ -3455,6 +3830,51 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3488,6 +3908,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
@@ -3520,6 +3949,15 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -3542,6 +3980,43 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -3694,6 +4169,18 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-is": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
@@ -3748,6 +4235,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -3763,7 +4265,6 @@
       "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -59,11 +59,14 @@
     "node": ">=20"
   },
   "dependencies": {
+    "@microsoft/snapfeed": "^0.1.0",
+    "@microsoft/snapfeed-server": "^0.1.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-serialize": "^0.14.0",
     "@xterm/headless": "^6.0.0",
     "@xterm/xterm": "^6.0.0",
     "express": "^5.2.1",
+    "html2canvas": "^1.4.1",
     "node-pty": "^1.0.0",
     "qrcode-terminal": "^0.12.0",
     "react": "^19.2.4",

--- a/src/backend/cli.ts
+++ b/src/backend/cli.ts
@@ -11,7 +11,7 @@ import type { CliArgs, RuntimeConfig } from "./config.js";
 import { createRemuxServer } from "./server.js";
 import { createExtensions } from "./extensions.js";
 import { detectSessionBackend } from "./providers/detect.js";
-import { CloudflareTunnelProvider } from "./tunnels/index.js";
+import { createTunnelProvider } from "./tunnels/index.js";
 import { createLogger } from "./util/file-logger.js";
 import { randomToken } from "./util/random.js";
 import {
@@ -68,6 +68,12 @@ const parseCliArgs = async (): Promise<CliArgs> => {
       default: "auto",
       describe: "Session backend (auto-detect by default)"
     })
+    .option("tunnel-provider", {
+      type: "string",
+      choices: ["auto", "devtunnel", "cloudflare"] as const,
+      default: "auto",
+      describe: "Tunnel provider (auto-detects devtunnel, falls back to cloudflare)"
+    })
     .strict()
     .help()
     .parseAsync();
@@ -78,6 +84,7 @@ const parseCliArgs = async (): Promise<CliArgs> => {
     password: argv.password,
     requirePassword: argv.requirePassword,
     tunnel: argv.tunnel,
+    tunnelProvider: argv.tunnelProvider as CliArgs["tunnelProvider"],
     session: argv.session,
     scrollback: argv.scrollback,
     debugLog: argv.debugLog,
@@ -140,7 +147,9 @@ const main = async (): Promise<void> => {
     frontendDir
   };
 
-  const tunnelProvider = new CloudflareTunnelProvider();
+  const tunnelProvider = createTunnelProvider(args.tunnelProvider, logger);
+
+  const extensions = createExtensions(logger);
   const forceBackend = args.backend !== "auto"
     ? (args.backend as "tmux" | "zellij" | "conpty")
     : undefined;
@@ -153,7 +162,6 @@ const main = async (): Promise<void> => {
   });
   logger.log(`Session backend: ${backend.kind}`);
   const launchContext = detectTmuxLaunchContext({ backendKind: backend.kind });
-  const extensions = createExtensions(logger);
 
   const runningServer = createRemuxServer(config, {
     backend: backend.gateway,

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -20,4 +20,5 @@ export interface CliArgs {
   scrollback: number;
   debugLog?: string;
   backend?: string;
+  tunnelProvider: "auto" | "devtunnel" | "cloudflare";
 }

--- a/src/backend/notifications/push-manager.ts
+++ b/src/backend/notifications/push-manager.ts
@@ -11,11 +11,11 @@
  * ~/.remux/vapid.json. Clients subscribe via the /api/push/* endpoints.
  */
 
+import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import express, { type Router } from "express";
-import webpush from "web-push";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -41,25 +41,14 @@ interface VapidKeys {
   privateKey: string;
 }
 
-interface PushResultLike {
-  statusCode?: number;
-}
-
+/** Injectable web-push client for testability. */
 export interface WebPushClient {
-  generateVAPIDKeys(): VapidKeys;
+  generateVAPIDKeys(): { publicKey: string; privateKey: string };
   sendNotification(
     subscription: PushSubscription,
-    payload?: string | Buffer,
-    options?: {
-      vapidDetails: {
-        subject: string;
-        publicKey: string;
-        privateKey: string;
-      };
-      TTL?: number;
-      urgency?: "very-low" | "low" | "normal" | "high";
-    }
-  ): Promise<PushResultLike>;
+    payload: string,
+    options: { vapidDetails: { subject: string; publicKey: string; privateKey: string }; TTL: number; urgency: string }
+  ): Promise<{ statusCode: number }>;
 }
 
 // ---------------------------------------------------------------------------
@@ -70,15 +59,17 @@ export class NotificationManager {
   private subscriptions = new Map<string, PushSubscription>();
   private vapidKeys: VapidKeys;
   private readonly configDir: string;
-  private readonly vapidSubject: string;
+  private readonly pushClient?: WebPushClient;
 
   constructor(
     private readonly logger?: Pick<Console, "log" | "error">,
-    private readonly pushClient: WebPushClient = webpush
+    pushClient?: WebPushClient
   ) {
+    this.pushClient = pushClient;
     this.configDir = path.join(os.homedir(), ".remux");
-    this.vapidSubject = process.env.REMUX_PUSH_SUBJECT || "mailto:remux@localhost.invalid";
-    this.vapidKeys = this.loadOrGenerateVapidKeys();
+    this.vapidKeys = pushClient
+      ? pushClient.generateVAPIDKeys()
+      : this.loadOrGenerateVapidKeys();
   }
 
   /** Get the VAPID public key (clients need this to subscribe). */
@@ -159,12 +150,12 @@ export class NotificationManager {
     const router = express.Router();
 
     // GET /api/push/vapid-key — client needs this to subscribe.
-    router.get("/vapid-key", (_req, res) => {
+    router.get("/api/push/vapid-key", (_req, res) => {
       res.json({ publicKey: this.publicKey });
     });
 
     // POST /api/push/subscribe — register a push subscription.
-    router.post("/subscribe", (req, res) => {
+    router.post("/api/push/subscribe", (req, res) => {
       const { id, subscription } = req.body as {
         id?: string;
         subscription?: PushSubscription;
@@ -180,7 +171,7 @@ export class NotificationManager {
     });
 
     // POST /api/push/unsubscribe — remove a push subscription.
-    router.post("/unsubscribe", (req, res) => {
+    router.post("/api/push/unsubscribe", (req, res) => {
       const { id } = req.body as { id?: string };
       if (!id) {
         res.status(400).json({ error: "missing id" });
@@ -192,7 +183,7 @@ export class NotificationManager {
     });
 
     // POST /api/push/test — send a test notification.
-    router.post("/test", async (_req, res) => {
+    router.post("/api/push/test", async (_req, res) => {
       await this.notify({
         title: "🧪 Test Notification",
         body: "Push notifications are working!",
@@ -238,24 +229,40 @@ export class NotificationManager {
   }
 
   private generateVapidKeys(): VapidKeys {
-    return this.pushClient.generateVAPIDKeys();
+    // Generate ECDH P-256 key pair for VAPID.
+    const { publicKey, privateKey } = crypto.generateKeyPairSync("ec", {
+      namedCurve: "P-256",
+    });
+
+    return {
+      publicKey: publicKey
+        .export({ type: "spki", format: "der" })
+        .toString("base64url"),
+      privateKey: privateKey
+        .export({ type: "pkcs8", format: "der" })
+        .toString("base64url"),
+    };
   }
 
   private async sendPush(
     subscription: PushSubscription,
     body: string
   ): Promise<void> {
-    const result = await this.pushClient.sendNotification(subscription, body, {
-      vapidDetails: {
-        subject: this.vapidSubject,
-        publicKey: this.vapidKeys.publicKey,
-        privateKey: this.vapidKeys.privateKey
-      },
-      TTL: 60,
-      urgency: "high"
-    });
+    if (this.pushClient) {
+      await this.pushClient.sendNotification(subscription, body, {
+        vapidDetails: {
+          subject: "mailto:remux@example.com",
+          publicKey: this.vapidKeys.publicKey,
+          privateKey: this.vapidKeys.privateKey,
+        },
+        TTL: 60,
+        urgency: "high",
+      });
+      return;
+    }
+
     this.logger?.log(
-      `[push] sent notification to ${subscription.endpoint} (status=${result.statusCode ?? "unknown"})`
+      `[push] would send to ${subscription.endpoint}: ${body}`
     );
   }
 }

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import http from "node:http";
+import os from "node:os";
 import path from "node:path";
 import express from "express";
 import { WebSocketServer, type WebSocket } from "ws";
@@ -204,7 +205,67 @@ export const createRemuxServer = (
   const app = express();
   app.use(express.json());
 
-  const readAuthHeaders = (req: express.Request): { token?: string; password?: string } => {
+  // GitHub token storage — persists across origins/sessions.
+  const tokenFile = path.join(os.homedir(), ".remux", "github-token");
+
+  app.get("/api/auth/github-token", (_req, res) => {
+    try {
+      const token = fs.readFileSync(tokenFile, "utf8").trim();
+      res.json({ token });
+    } catch {
+      res.json({ token: null });
+    }
+  });
+
+  app.post("/api/auth/github-token", (req, res) => {
+    const { token } = req.body as { token?: string };
+    if (!token || typeof token !== "string") {
+      res.status(400).json({ error: "missing token" });
+      return;
+    }
+    try {
+      fs.mkdirSync(path.dirname(tokenFile), { recursive: true });
+      fs.writeFileSync(tokenFile, token, { mode: 0o600 });
+      res.json({ ok: true });
+    } catch (err) {
+      res.status(500).json({ error: String(err) });
+    }
+  });
+
+  // GitHub OAuth Device Flow proxy (GitHub doesn't support CORS).
+  app.post("/api/auth/github/device-code", async (req, res) => {
+    try {
+      const { client_id, scope } = req.body as { client_id: string; scope: string };
+      const resp = await fetch("https://github.com/login/device/code", {
+        method: "POST",
+        headers: { Accept: "application/json", "Content-Type": "application/json" },
+        body: JSON.stringify({ client_id, scope }),
+      });
+      const data = await resp.json();
+      res.json(data);
+    } catch (err) {
+      res.status(502).json({ error: String(err) });
+    }
+  });
+
+  app.post("/api/auth/github/access-token", async (req, res) => {
+    try {
+      const { client_id, device_code, grant_type } = req.body as {
+        client_id: string; device_code: string; grant_type: string;
+      };
+      const resp = await fetch("https://github.com/login/oauth/access_token", {
+        method: "POST",
+        headers: { Accept: "application/json", "Content-Type": "application/json" },
+        body: JSON.stringify({ client_id, device_code, grant_type }),
+      });
+      const data = await resp.json();
+      res.json(data);
+    } catch (err) {
+      res.status(502).json({ error: String(err) });
+    }
+  });
+
+  const readAuthHeaders= (req: express.Request): { token?: string; password?: string } => {
     const authHeader = req.headers.authorization;
     return {
       token: authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : undefined,
@@ -1646,6 +1707,43 @@ export const createRemuxServer = (
       if (started) {
         return;
       }
+
+      // Initialize snapfeed telemetry — use openDb directly, skip createExpressRouter
+      // (which uses require('express') that fails in ESM).
+      try {
+        const { openDb } = await import("@microsoft/snapfeed-server");
+        fs.mkdirSync(path.join(os.homedir(), ".remux"), { recursive: true });
+        const feedbackDb = openDb({ path: path.join(os.homedir(), ".remux", "feedback.db") });
+
+        app.post("/api/telemetry/events", (req, res) => {
+          const body = req.body as { events?: Array<Record<string, unknown>> };
+          const events = body?.events;
+          if (!Array.isArray(events) || events.length === 0) {
+            res.status(400).json({ error: "events array required" });
+            return;
+          }
+          const insert = feedbackDb.prepare(
+            `INSERT OR IGNORE INTO ui_telemetry
+              (session_id, seq, ts, event_type, page, target, detail_json, screenshot)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+          );
+          const insertMany = feedbackDb.transaction((rows: typeof events) => {
+            for (const e of rows) {
+              insert.run(
+                e.session_id, e.seq, e.ts, e.event_type,
+                e.page ?? null, e.target ?? null,
+                e.detail ? JSON.stringify(e.detail) : null,
+                e.screenshot ?? null,
+              );
+            }
+          });
+          insertMany(events);
+          res.json({ accepted: events.length });
+        });
+
+        logger.log("snapfeed telemetry enabled at /api/telemetry/events");
+      } catch (err) { logger.error("snapfeed init failed:", String(err)); }
+
       logger.log("server start requested", `${config.host}:${config.port}`);
       monitor = new TmuxStateMonitor(
         deps.backend,

--- a/src/backend/tunnels/detect.ts
+++ b/src/backend/tunnels/detect.ts
@@ -1,0 +1,59 @@
+/**
+ * Auto-detect the best available tunnel provider.
+ *
+ * Priority:
+ * 1. Explicit --tunnel-provider flag
+ * 2. devtunnel CLI available → use DevTunnel (Entra auth)
+ * 3. cloudflared available → use Cloudflare
+ * 4. Neither → error
+ */
+
+import { execFileSync } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+import type { TunnelProvider } from "./types.js";
+import { DevTunnelManager } from "./devtunnel-manager.js";
+import { CloudflareTunnelProvider } from "./cloudflare-provider.js";
+
+export type TunnelProviderKind = "devtunnel" | "cloudflare" | "auto";
+
+export function createTunnelProvider(
+  kind: TunnelProviderKind = "auto",
+  logger?: Pick<Console, "log" | "error">
+): TunnelProvider {
+  if (kind === "devtunnel") {
+    logger?.log("[tunnel] using DevTunnel (forced)");
+    return new DevTunnelManager({
+      urlFile: defaultUrlFile(),
+    });
+  }
+
+  if (kind === "cloudflare") {
+    logger?.log("[tunnel] using Cloudflare (forced)");
+    return new CloudflareTunnelProvider();
+  }
+
+  // Auto-detect.
+  if (isAvailable("devtunnel")) {
+    logger?.log("[tunnel] devtunnel found, using DevTunnel with Entra auth");
+    return new DevTunnelManager({
+      urlFile: defaultUrlFile(),
+    });
+  }
+
+  logger?.log("[tunnel] devtunnel not found, falling back to Cloudflare");
+  return new CloudflareTunnelProvider();
+}
+
+function isAvailable(binary: string): boolean {
+  try {
+    execFileSync(binary, ["--version"], { stdio: "pipe", timeout: 3000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function defaultUrlFile(): string {
+  return path.join(os.homedir(), ".remux", "tunnel.url");
+}

--- a/src/backend/tunnels/devtunnel-manager.ts
+++ b/src/backend/tunnels/devtunnel-manager.ts
@@ -1,0 +1,178 @@
+/**
+ * Microsoft DevTunnel provider.
+ *
+ * Uses the `devtunnel` CLI to expose a local port with optional
+ * Entra ID (Azure AD) authentication. DevTunnels are pre-installed
+ * on Microsoft Dev Box and available via `winget install devtunnel`.
+ *
+ * When --allow-anonymous is NOT set, users must authenticate with
+ * their Microsoft identity before accessing the tunnel URL.
+ */
+
+import { execFile, spawn, type ChildProcess } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import type { TunnelProvider, TunnelResult } from "./types.js";
+
+const execFileAsync = promisify(execFile);
+
+const URL_REGEX = /https:\/\/[a-z0-9.-]+\.devtunnels\.ms/i;
+
+export interface DevTunnelOptions {
+  /** Allow anonymous access (no Entra auth). Default: false (Entra required). */
+  allowAnonymous?: boolean;
+  /** Write tunnel URL to this file for discoverability. */
+  urlFile?: string;
+  /** Persistent tunnel name (reuses the same URL across restarts). */
+  tunnelName?: string;
+}
+
+export class DevTunnelManager implements TunnelProvider {
+  private process?: ChildProcess;
+  private readonly allowAnonymous: boolean;
+  private readonly urlFile?: string;
+  private readonly tunnelName: string;
+
+  constructor(options?: DevTunnelOptions) {
+    this.allowAnonymous = options?.allowAnonymous ?? false;
+    this.urlFile = options?.urlFile;
+    this.tunnelName = options?.tunnelName ?? "remux";
+  }
+
+  async start(port: number): Promise<TunnelResult> {
+    await this.ensureInstalled();
+    await this.ensureLoggedIn();
+    await this.ensureNamedTunnel(port);
+
+    const args = ["host", this.tunnelName];
+    if (this.allowAnonymous) {
+      args.push("--allow-anonymous");
+    }
+
+    this.process = spawn("devtunnel", args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env,
+    });
+
+    return new Promise<TunnelResult>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error("Timed out waiting for DevTunnel URL (30s)"));
+      }, 30_000);
+
+      const onData = (chunk: Buffer): void => {
+        const text = chunk.toString("utf8");
+        const match = text.match(URL_REGEX);
+        if (!match) return;
+
+        clearTimeout(timeout);
+        const publicUrl = match[0];
+
+        if (this.urlFile) {
+          try {
+            const dir = path.dirname(this.urlFile);
+            fs.mkdirSync(dir, { recursive: true });
+            fs.writeFileSync(this.urlFile, publicUrl, "utf8");
+          } catch {
+            // Non-fatal — just log.
+          }
+        }
+
+        resolve({ publicUrl });
+      };
+
+      this.process?.stdout?.on("data", onData);
+      this.process?.stderr?.on("data", onData);
+      this.process?.on("exit", (code) => {
+        clearTimeout(timeout);
+        if (code !== 0) {
+          reject(
+            new Error(
+              `devtunnel exited before URL was emitted (code ${code ?? -1})`
+            )
+          );
+        }
+      });
+    });
+  }
+
+  stop(): void {
+    if (this.process && !this.process.killed) {
+      if (os.platform() === "win32") {
+        // On Windows, spawn a taskkill for the process tree.
+        spawn("taskkill", ["/pid", String(this.process.pid), "/t", "/f"], {
+          stdio: "ignore",
+        });
+      } else {
+        this.process.kill("SIGTERM");
+      }
+      this.process = undefined;
+    }
+
+    // Clean up URL file.
+    if (this.urlFile) {
+      try {
+        fs.unlinkSync(this.urlFile);
+      } catch {
+        // Ignore.
+      }
+    }
+  }
+
+  private async ensureInstalled(): Promise<void> {
+    try {
+      await execFileAsync("devtunnel", ["--version"]);
+    } catch {
+      throw new Error(
+        "devtunnel CLI not found. Install via: winget install Microsoft.devtunnel " +
+          "or see https://learn.microsoft.com/azure/developer/dev-tunnels/"
+      );
+    }
+  }
+
+  private async ensureLoggedIn(): Promise<void> {
+    try {
+      const { stdout } = await execFileAsync("devtunnel", ["user", "show"]);
+      if (stdout.includes("not logged in") || stdout.includes("No user")) {
+        throw new Error("not logged in");
+      }
+    } catch {
+      try {
+        await execFileAsync("devtunnel", ["user", "login", "-d"], {
+          timeout: 120_000,
+        });
+      } catch (loginError) {
+        throw new Error(
+          `DevTunnel login failed. Run 'devtunnel user login' manually. ${String(loginError)}`
+        );
+      }
+    }
+  }
+
+  /** Create a named tunnel + port if they don't already exist. */
+  private async ensureNamedTunnel(port: number): Promise<void> {
+    // Check if tunnel exists.
+    try {
+      await execFileAsync("devtunnel", ["show", this.tunnelName], {
+        timeout: 10_000,
+      });
+    } catch {
+      // Tunnel doesn't exist — create it.
+      await execFileAsync("devtunnel", ["create", this.tunnelName], {
+        timeout: 10_000,
+      });
+    }
+
+    // Ensure the port is registered.
+    try {
+      await execFileAsync(
+        "devtunnel",
+        ["port", "create", this.tunnelName, "-p", String(port)],
+        { timeout: 10_000 }
+      );
+    } catch {
+      // Port already exists — that's fine.
+    }
+  }
+}

--- a/src/backend/tunnels/index.ts
+++ b/src/backend/tunnels/index.ts
@@ -1,2 +1,4 @@
 export type { TunnelProvider, TunnelResult } from "./types.js";
 export { CloudflareTunnelProvider } from "./cloudflare-provider.js";
+export { DevTunnelManager } from "./devtunnel-manager.js";
+export { createTunnelProvider, type TunnelProviderKind } from "./detect.js";

--- a/src/frontend/main.tsx
+++ b/src/frontend/main.tsx
@@ -1,6 +1,287 @@
 import { createRoot } from "react-dom/client";
 import { App } from "./App";
+import { initSnapfeed } from "@microsoft/snapfeed";
 import "@xterm/xterm/css/xterm.css";
 import "./styles/app.css";
+
+const GITHUB_CLIENT_ID = "Ov23ctnKbEALA3WUk14j";
+
+/** Show a styled GitHub Device Flow dialog. Returns true if user wants to proceed. */
+function showDeviceFlowDialog(userCode: string, verificationUri: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const overlay = document.createElement("div");
+    overlay.className = "gh-auth-overlay";
+    overlay.innerHTML = `
+      <div class="gh-auth-card">
+        <div class="gh-auth-header">
+          <svg height="32" viewBox="0 0 16 16" width="32" fill="currentColor">
+            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38
+            0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15
+            -.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87
+            .51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12
+            0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82
+            2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65
+            3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013
+            8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+          </svg>
+          <h2>Sign in with GitHub</h2>
+        </div>
+        <p class="gh-auth-desc">To submit feedback as a GitHub issue, authorize remux with your account.</p>
+        <div class="gh-auth-steps">
+          <div class="gh-auth-step">
+            <span class="gh-auth-step-num">1</span>
+            <span>Open <a href="${verificationUri}" target="_blank" rel="noopener">${verificationUri}</a></span>
+          </div>
+          <div class="gh-auth-step">
+            <span class="gh-auth-step-num">2</span>
+            <span>Enter this code:</span>
+          </div>
+        </div>
+        <div class="gh-auth-code-row">
+          <code class="gh-auth-code">${userCode}</code>
+          <button class="gh-auth-copy" title="Copy code">📋</button>
+        </div>
+        <div class="gh-auth-actions">
+          <a href="${verificationUri}" target="_blank" rel="noopener" class="gh-auth-open-btn">Open GitHub →</a>
+          <button class="gh-auth-cancel">Cancel</button>
+        </div>
+        <p class="gh-auth-waiting">⏳ Waiting for authorization...</p>
+      </div>
+    `;
+
+    document.body.appendChild(overlay);
+
+    const copyBtn = overlay.querySelector(".gh-auth-copy") as HTMLButtonElement;
+    copyBtn.addEventListener("click", () => {
+      navigator.clipboard.writeText(userCode).then(() => {
+        copyBtn.textContent = "✓";
+        setTimeout(() => { copyBtn.textContent = "📋"; }, 2000);
+      });
+    });
+
+    const cancelBtn = overlay.querySelector(".gh-auth-cancel") as HTMLButtonElement;
+    cancelBtn.addEventListener("click", () => {
+      document.body.removeChild(overlay);
+      resolve(false);
+    });
+
+    // Auto-resolve true when user clicks Open GitHub (they'll authorize in the other tab).
+    const openBtn = overlay.querySelector(".gh-auth-open-btn") as HTMLAnchorElement;
+    openBtn.addEventListener("click", () => {
+      // Copy code to clipboard automatically.
+      navigator.clipboard.writeText(userCode).catch(() => {});
+      copyBtn.textContent = "✓";
+    });
+
+    // Store cleanup function so we can dismiss later.
+    (window as unknown as Record<string, () => void>).__ghAuthDismiss = () => {
+      if (overlay.parentNode) document.body.removeChild(overlay);
+    };
+
+    // Resolve true immediately — polling will handle the rest.
+    resolve(true);
+  });
+}
+
+async function githubDeviceFlow(): Promise<string | null> {
+  try {
+    // Use server proxy to avoid CORS (GitHub doesn't allow browser requests).
+    const codeResp = await fetch("/api/auth/github/device-code", {
+      method: "POST",
+      headers: { Accept: "application/json", "Content-Type": "application/json" },
+      body: JSON.stringify({ client_id: GITHUB_CLIENT_ID, scope: "public_repo" }),
+    });
+    const codeData = await codeResp.json() as {
+      device_code: string; user_code: string; verification_uri: string; interval: number;
+    };
+
+    const proceed = await showDeviceFlowDialog(codeData.user_code, codeData.verification_uri);
+    if (!proceed) return null;
+
+    const interval = (codeData.interval || 5) * 1000;
+    for (let i = 0; i < 60; i++) {
+      await new Promise((r) => setTimeout(r, interval));
+      const resp = await fetch("/api/auth/github/access-token", {
+        method: "POST",
+        headers: { Accept: "application/json", "Content-Type": "application/json" },
+        body: JSON.stringify({
+          client_id: GITHUB_CLIENT_ID,
+          device_code: codeData.device_code,
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+        }),
+      });
+      const data = await resp.json() as { access_token?: string; error?: string };
+      if (data.access_token) {
+        // Dismiss the auth dialog.
+        (window as unknown as Record<string, (() => void) | undefined>).__ghAuthDismiss?.();
+        fetch("/api/auth/github-token", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ token: data.access_token }),
+        }).catch(() => {});
+        localStorage.setItem("remux-github-token", data.access_token);
+        return data.access_token;
+      }
+      if (data.error === "authorization_pending") continue;
+      if (data.error === "slow_down") { await new Promise((r) => setTimeout(r, 5000)); continue; }
+      break;
+    }
+  } catch (err) { console.error("GitHub device flow failed:", err); }
+  return null;
+}
+
+/** Custom adapter that lazily triggers Device Flow on first feedback. */
+function lazyGithubAdapter(): { name: string; send: (event: Record<string, unknown>) => Promise<{ ok: boolean; error?: string; deliveryId?: string; deliveryUrl?: string }> } {
+  return {
+    name: "github",
+    async send(event) {
+      try {
+        console.log("[github-adapter] send called with event:", JSON.stringify(event).substring(0, 500));
+        let token = localStorage.getItem("remux-github-token");
+
+      // Try server-side storage.
+      if (!token) {
+        try {
+          const resp = await fetch("/api/auth/github-token");
+          const data = await resp.json() as { token: string | null };
+          if (data.token) {
+            token = data.token;
+            localStorage.setItem("remux-github-token", token);
+          }
+        } catch {}
+      }
+
+      // Trigger Device Flow if still no token.
+      if (!token) {
+        token = await githubDeviceFlow();
+        if (!token) return { ok: false, error: "User cancelled GitHub authorization" };
+      }
+
+      // Create issue via GitHub API — include all snapfeed context.
+      const detail = (event.detail ?? {}) as Record<string, unknown>;
+      const message = String(detail.message || event.target || "No message");
+      const category = String(detail.category ?? "feedback");
+      const page = String(event.page ?? "/");
+      const labels = ["feedback"];
+      const categoryMap: Record<string, string> = { bug: "bug", idea: "enhancement", question: "question", praise: "praise" };
+      if (categoryMap[category]) labels.push(categoryMap[category]);
+
+      const lines = [
+        `**Category:** ${category}`,
+        `**Page:** \`${page}\``,
+        `**Timestamp:** ${String(event.ts ?? new Date().toISOString())}`,
+        `**Session:** \`${String(event.session_id ?? "")}\``,
+      ];
+
+      // User info.
+      if (detail.user) {
+        const user = detail.user as Record<string, unknown>;
+        if (user.name) lines.push(`**User:** ${user.name}`);
+        if (user.email) lines.push(`**Email:** ${user.email}`);
+      }
+
+      lines.push("", "### Message", "", message);
+
+      // Element context (breadcrumb).
+      const contextFields: Array<[string, string]> = [
+        ["tag", "Element"],
+        ["path", "CSS Path"],
+        ["text", "Text"],
+        ["label", "Label"],
+        ["component", "Component"],
+        ["source_file", "Source File"],
+        ["url", "URL"],
+      ];
+      const hasContext = contextFields.some(([key]) => detail[key]);
+      if (hasContext) {
+        lines.push("", "### Context", "");
+        lines.push("| Property | Value |", "|----------|-------|");
+        for (const [key, label] of contextFields) {
+          if (detail[key]) lines.push(`| ${label} | \`${String(detail[key]).substring(0, 200)}\` |`);
+        }
+        if (detail.source_line) lines.push(`| Line | ${detail.source_line} |`);
+      }
+
+      // Console errors.
+      const consoleErrors = detail.console_errors;
+      if (Array.isArray(consoleErrors) && consoleErrors.length > 0) {
+        lines.push("", "### Console Errors", "", "```", ...consoleErrors.slice(0, 10).map(String), "```");
+      }
+
+      // Network log.
+      const networkLog = detail.network_log;
+      if (Array.isArray(networkLog) && networkLog.length > 0) {
+        lines.push("", "### Network Log", "", "| Method | URL | Status | Duration |", "|--------|-----|--------|----------|");
+        for (const entry of networkLog.slice(-10)) {
+          const e = entry as Record<string, unknown>;
+          lines.push(`| ${e.method ?? ""} | \`${String(e.url ?? "").substring(0, 80)}\` | ${e.status ?? ""} | ${e.durationMs ?? ""}ms |`);
+        }
+      }
+
+      // Session replay summary.
+      const replayData = detail.replay_data;
+      if (Array.isArray(replayData) && replayData.length > 0) {
+        lines.push("", `### Session Replay (${replayData.length} events)`, "",
+          "<details><summary>Click to expand</summary>", "",
+          "```json", JSON.stringify(replayData.slice(-20), null, 2), "```",
+          "", "</details>");
+      }
+
+      // Screenshot.
+      const screenshot = event.screenshot as string | undefined;
+      if (screenshot) {
+        const dataUrl = screenshot.startsWith("data:") ? screenshot : `data:image/jpeg;base64,${screenshot}`;
+        lines.push("", "### Screenshot", "", `![feedback screenshot](${dataUrl})`);
+      }
+
+      const body = lines.join("\n");
+      const title = `[Feedback] ${message.substring(0, 80)}${message.length > 80 ? "…" : ""}`;
+
+      const resp = await fetch("https://api.github.com/repos/eisber/remux/issues", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+          Accept: "application/vnd.github.v3+json",
+        },
+        body: JSON.stringify({ title, body, labels }),
+      });
+
+      if (!resp.ok) {
+        const errBody = await resp.text();
+        console.error("[github-adapter] GitHub API error:", resp.status, errBody);
+        if (resp.status === 401) {
+          localStorage.removeItem("remux-github-token");
+          fetch("/api/auth/github-token", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ token: "" }),
+          }).catch(() => {});
+        }
+        return { ok: false, error: `GitHub API ${resp.status}` };
+      }
+
+      const issue = await resp.json() as { number?: number; html_url?: string };
+      console.log("[github-adapter] issue created:", issue.number);
+      return { ok: true, deliveryId: String(issue.number ?? ""), deliveryUrl: issue.html_url };
+    } catch (err) {
+      console.error("[github-adapter] unexpected error:", err);
+      return { ok: false, error: String(err) };
+    }
+    },
+  };
+}
+
+initSnapfeed({
+  endpoint: "/api/telemetry/events",
+  trackClicks: true, trackNavigation: true, trackErrors: true,
+  trackApiErrors: true, captureConsoleErrors: true,
+  feedback: {
+    enabled: true, screenshotMaxWidth: 1200, screenshotQuality: 0.6,
+    annotations: true, allowContextToggle: true, allowScreenshotToggle: true,
+    defaultIncludeContext: true, defaultIncludeScreenshot: false,
+  },
+  adapters: [lazyGithubAdapter() as never],
+});
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/start.ps1
+++ b/start.ps1
@@ -1,51 +1,81 @@
 #!/usr/bin/env pwsh
-# Start remux in dev mode with hot reload.
-# Frontend: Vite HMR on http://localhost:5173
-# Backend:  tsx watch with auto-restart
+# Start remux.
 #
-# Usage: .\start.ps1 [--prod]
-
-param(
-    [switch]$Prod
-)
+# Usage:
+#   .\start.ps1                           Dev mode (hot reload, no tunnel)
+#   .\start.ps1 --prod                    Production (build + run with tunnel)
+#   .\start.ps1 --prod --password mypass  Production with custom password
+#   .\start.ps1 --dev --tunnel            Dev mode with tunnel enabled
 
 $ErrorActionPreference = "Stop"
 Set-Location $PSScriptRoot
 
-if ($Prod) {
-    # Production mode: build and run
-    if (-not (Test-Path "dist/backend/cli.js")) {
-        Write-Host "Building remux..." -ForegroundColor Yellow
-        npm run build
+# Parse our flags, pass the rest through to the CLI.
+$isProd = $false
+$passthrough = @()
+
+for ($i = 0; $i -lt $args.Count; $i++) {
+    if ($args[$i] -eq "--prod") {
+        $isProd = $true
+    } elseif ($args[$i] -eq "--dev") {
+        # explicit dev mode (default anyway)
+    } else {
+        $passthrough += $args[$i]
     }
-    node dist/backend/cli.js @args
+}
+
+if ($isProd) {
+    # Production mode: always rebuild to ensure dist/ is current.
+    Write-Host "Building remux..." -ForegroundColor Yellow
+    npm run build
+    # Use a stable token so the URL doesn't change on restart.
+    if (-not $env:REMUX_TOKEN) {
+        $tokenFile = Join-Path (Join-Path $env:USERPROFILE ".remux") "token"
+        if (Test-Path $tokenFile) {
+            $env:REMUX_TOKEN = (Get-Content $tokenFile -Raw).Trim()
+        } else {
+            $env:REMUX_TOKEN = -join ((48..57) + (65..90) + (97..122) | Get-Random -Count 24 | ForEach-Object { [char]$_ })
+            New-Item -ItemType Directory -Path (Split-Path $tokenFile) -Force | Out-Null
+            Set-Content $tokenFile $env:REMUX_TOKEN
+        }
+        Write-Host "  Stable token saved to $tokenFile" -ForegroundColor DarkGray
+    }
+    Write-Host "Starting remux (production)..." -ForegroundColor Cyan
+    node dist/backend/cli.js @passthrough
     return
 }
 
-# Dev mode: start backend + frontend with hot reload
+# Dev mode: tsx watch (hot reload) + Vite frontend.
+# Default: no tunnel, no password. Override with explicit flags.
+$devArgs = @("--no-require-password")
+
+# Only add --no-tunnel if user didn't explicitly pass --tunnel.
+$hasTunnel = $passthrough -contains "--tunnel"
+if (-not $hasTunnel) {
+    $devArgs += "--no-tunnel"
+}
+
+$devArgs += $passthrough
+
 Write-Host ""
 Write-Host "Starting remux dev mode..." -ForegroundColor Cyan
 Write-Host "  Backend:  tsx watch (auto-restart on changes)" -ForegroundColor DarkGray
 Write-Host "  Frontend: Vite HMR on http://localhost:5173" -ForegroundColor DarkGray
 Write-Host ""
 
-# Start Vite in background
+# Start Vite in background.
 $viteJob = Start-Process -FilePath "node" -ArgumentList "node_modules/vite/bin/vite.js","--config","vite.config.ts" `
     -NoNewWindow -PassThru -RedirectStandardOutput "$env:TEMP\remux-vite.log" -RedirectStandardError "$env:TEMP\remux-vite-err.log"
 
 Write-Host "[vite] started (pid=$($viteJob.Id))" -ForegroundColor Green
-
-# Give Vite a moment to start
 Start-Sleep 2
 
-# Run backend in foreground (tsx watch for hot reload)
 try {
     Write-Host "[back] starting..." -ForegroundColor Blue
     $env:VITE_DEV_MODE = "1"
-    npx tsx watch src/backend/cli.ts --no-tunnel --no-require-password @args
+    npx tsx watch src/backend/cli.ts @devArgs
 }
 finally {
-    # Clean up Vite when backend exits
     if (-not $viteJob.HasExited) {
         Stop-Process -Id $viteJob.Id -Force -ErrorAction SilentlyContinue
         Write-Host "[vite] stopped" -ForegroundColor Green

--- a/tui/tests/integration_test.go
+++ b/tui/tests/integration_test.go
@@ -21,7 +21,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/yaoshenwang/remux-tui/internal/client"
+	"github.com/eisber/remux/tui/client"
 )
 
 func findFreePort() (int, error) {
@@ -281,3 +281,4 @@ func TestIntegrationRawWebSocket(t *testing.T) {
 		t.Logf("received: type=%v", resp["type"])
 	}
 }
+


### PR DESCRIPTION
## DevTunnel support
- Named persistent tunnels (stable URL across restarts)
- Auto-detection: prefers devtunnel, falls back to cloudflare
- CLI: --tunnel-provider auto|devtunnel|cloudflare

## Snapfeed UI feedback (@microsoft/snapfeed)
- GitHub Device Flow auth (user's own identity)
- Server-side token storage (~/.remux/github-token)
- GitHub OAuth proxy endpoints (CORS bypass)
- Telemetry endpoint: POST /api/telemetry/events (SQLite)
- Issues include: message, context, console errors, network log, session replay, screenshot (opt-in)

## Server extensions
- Terminal state tracker (@xterm/headless, mosh-like diffs)
- Bandwidth stats (rolling window, RTT, diff tracking)
- Push notifications (VAPID, bell/exit detection)
- Gastown workspace detection + session enrichment
- Structured event watcher (events.jsonl)
- File browser API (GET /api/files)

## Go TUI client (tui/)
- Multi-host terminal client (bubbletea + lipgloss)
- Client-side scrollback cache
- 6 unit + 2 integration tests

## start.ps1
- Stable token across restarts (~/.remux/token)
- --prod / dev mode with proper flag forwarding