### PR TITLE
Release dev to main (v0.1.60)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remux",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remux",
-      "version": "0.1.59",
+      "version": "0.1.60",
       "license": "MIT",
       "dependencies": {
         "@microsoft/snapfeed": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remux",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "description": "Remote workspace cockpit for terminal-first work, with tmux, zellij, and conpty backends",
   "license": "MIT",
   "repository": {

--- a/scripts/install-launchd.sh
+++ b/scripts/install-launchd.sh
@@ -11,7 +11,11 @@ mkdir -p "$HOME/Library/LaunchAgents"
 write_runtime_plist() {
   local name="$1"
   local plist
+  local runtime_node_bin
+  local runtime_path
   plist="$(runtime_plist_path "$name")"
+  runtime_node_bin="$(resolve_runtime_node_bin)"
+  runtime_path="$(runtime_shell_path)"
 
   cat > "$plist" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
@@ -22,7 +26,7 @@ write_runtime_plist() {
     <string>$(runtime_service "$name")</string>
     <key>ProgramArguments</key>
     <array>
-      <string>/opt/homebrew/bin/node</string>
+      <string>$runtime_node_bin</string>
       <string>dist/backend/cli.js</string>
       <string>--host</string>
       <string>0.0.0.0</string>
@@ -42,7 +46,7 @@ write_runtime_plist() {
       <key>REMUX_RUNTIME_BRANCH</key>
       <string>$(runtime_branch "$name")</string>
       <key>PATH</key>
-      <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+      <string>$runtime_path</string>
       <key>TERM</key>
       <string>xterm-256color</string>
       <key>HOME</key>
@@ -68,8 +72,10 @@ EOF
 write_sync_plist() {
   local plist
   local runtime_manager_dir
+  local runtime_path
   plist="$(runtime_sync_plist_path)"
   runtime_manager_dir="$(runtime_dir dev)"
+  runtime_path="$(runtime_shell_path)"
 
   cat > "$plist" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
@@ -100,7 +106,7 @@ write_sync_plist() {
     <key>EnvironmentVariables</key>
     <dict>
       <key>PATH</key>
-      <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+      <string>$runtime_path</string>
       <key>HOME</key>
       <string>$HOME</string>
       <key>LANG</key>

--- a/scripts/runtime-lib.sh
+++ b/scripts/runtime-lib.sh
@@ -8,7 +8,92 @@ RUNTIME_STATE_ROOT="${REMUX_RUNTIME_STATE_ROOT:-$HOME/.remux}"
 RUNTIME_WORKTREE_ROOT="${REMUX_RUNTIME_WORKTREE_ROOT:-$RUNTIME_STATE_ROOT/runtime-worktrees}"
 # Keep the sync lock outside ephemeral checkouts so launchd sync and Actions deploys share it.
 SYNC_LOCK_DIR="${REMUX_RUNTIME_SYNC_LOCK_DIR:-$RUNTIME_STATE_ROOT/runtime-sync.lock}"
+RUNTIME_BASE_PATH="${REMUX_RUNTIME_BASE_PATH:-/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin}"
 LAUNCHD_GUI_DOMAIN="gui/$(id -u)"
+
+runtime_node_candidates() {
+  if [[ -n "${REMUX_RUNTIME_NODE_BIN:-}" ]]; then
+    printf '%s\n' "$REMUX_RUNTIME_NODE_BIN"
+    return 0
+  fi
+
+  if [[ -n "${REMUX_RUNTIME_NODE_SEARCH_PATHS:-}" ]]; then
+    local -a candidates
+    local IFS=':'
+    read -r -a candidates <<<"$REMUX_RUNTIME_NODE_SEARCH_PATHS" || true
+    printf '%s\n' "${candidates[@]}"
+    return 0
+  fi
+
+  printf '%s\n' \
+    /opt/homebrew/opt/node@22/bin/node \
+    /opt/homebrew/opt/node@20/bin/node \
+    /usr/local/opt/node@22/bin/node \
+    /usr/local/opt/node@20/bin/node
+
+  command -v node 2>/dev/null || true
+}
+
+resolve_runtime_node_bin() {
+  local candidate
+
+  while IFS= read -r candidate; do
+    if [[ -n "$candidate" && -x "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done < <(runtime_node_candidates)
+
+  echo "[runtime] unable to resolve a supported node binary" >&2
+  return 1
+}
+
+runtime_node_dir() {
+  dirname "$(resolve_runtime_node_bin)"
+}
+
+resolve_runtime_npm_bin() {
+  local candidate
+
+  if [[ -n "${REMUX_RUNTIME_NPM_BIN:-}" ]]; then
+    if [[ -x "$REMUX_RUNTIME_NPM_BIN" ]]; then
+      printf '%s\n' "$REMUX_RUNTIME_NPM_BIN"
+      return 0
+    fi
+    echo "[runtime] REMUX_RUNTIME_NPM_BIN is not executable: $REMUX_RUNTIME_NPM_BIN" >&2
+    return 1
+  fi
+
+  candidate="$(runtime_node_dir)/npm"
+  if [[ -x "$candidate" ]]; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  candidate="$(command -v npm 2>/dev/null || true)"
+  if [[ -n "$candidate" && -x "$candidate" ]]; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  echo "[runtime] unable to resolve npm for the runtime toolchain" >&2
+  return 1
+}
+
+runtime_shell_path() {
+  printf '%s:%s\n' "$(runtime_node_dir)" "$RUNTIME_BASE_PATH"
+}
+
+run_runtime_npm() {
+  local dir="$1"
+  shift
+  local npm_bin
+  npm_bin="$(resolve_runtime_npm_bin)"
+  (
+    cd "$dir"
+    PATH="$(runtime_shell_path)" "$npm_bin" "$@"
+  )
+}
 
 ensure_instance_name() {
   case "$1" in
@@ -108,7 +193,7 @@ json_field_or_empty() {
   local json="$1"
   local field="$2"
 
-  node - "$json" "$field" <<'NODE'
+  "$(resolve_runtime_node_bin)" - "$json" "$field" <<'NODE'
 const [json, field] = process.argv.slice(2);
 try {
   const value = JSON.parse(json)[field];
@@ -135,7 +220,7 @@ origin_sha_for() {
 origin_version_for() {
   ensure_instance_name "$1"
   git -C "$PROJECT_DIR" show "origin/$(runtime_branch "$1"):package.json" \
-    | node -e 'let raw="";process.stdin.on("data",d=>raw+=d);process.stdin.on("end",()=>process.stdout.write(JSON.parse(raw).version));'
+    | "$(resolve_runtime_node_bin)" -e 'let raw="";process.stdin.on("data",d=>raw+=d);process.stdin.on("end",()=>process.stdout.write(JSON.parse(raw).version));'
 }
 
 current_worktree_sha_for() {
@@ -147,7 +232,7 @@ install_runtime_dependencies() {
   local dir="$1"
   # Deploy runners may export NODE_ENV=production or omit devDependencies by
   # default, but the runtime quality gate requires TypeScript/Vitest typings.
-  (cd "$dir" && npm ci --include=dev)
+  run_runtime_npm "$dir" ci --include=dev
 }
 
 worktree_is_clean() {
@@ -175,7 +260,11 @@ verify_runtime_plist() {
   ensure_instance_name "$1"
   local name="$1"
   local plist
+  local expected_node_bin
+  local expected_path
   plist="$(runtime_plist_path "$name")"
+  expected_node_bin="$(resolve_runtime_node_bin)"
+  expected_path="$(runtime_shell_path)"
 
   if [[ ! -f "$plist" ]]; then
     echo "[runtime] missing launchd plist for $name: $plist" >&2
@@ -183,14 +272,26 @@ verify_runtime_plist() {
     return 1
   fi
 
-  if ! grep -q "$(runtime_dir "$name")" "$plist"; then
+  if ! grep -Fq "$(runtime_dir "$name")" "$plist"; then
     echo "[runtime] $plist does not point to $(runtime_dir "$name")" >&2
     echo "[runtime] rerun: npm run runtime:install-launchd" >&2
     return 1
   fi
 
-  if ! grep -q "REMUX_RUNTIME_BRANCH" "$plist"; then
+  if ! grep -Fq "REMUX_RUNTIME_BRANCH" "$plist"; then
     echo "[runtime] $plist does not export REMUX_RUNTIME_BRANCH" >&2
+    echo "[runtime] rerun: npm run runtime:install-launchd" >&2
+    return 1
+  fi
+
+  if ! grep -Fq "$expected_node_bin" "$plist"; then
+    echo "[runtime] $plist does not point to the resolved node binary: $expected_node_bin" >&2
+    echo "[runtime] rerun: npm run runtime:install-launchd" >&2
+    return 1
+  fi
+
+  if ! grep -Fq "$expected_path" "$plist"; then
+    echo "[runtime] $plist does not prefix PATH with the resolved runtime toolchain" >&2
     echo "[runtime] rerun: npm run runtime:install-launchd" >&2
     return 1
   fi

--- a/scripts/sync-runtime.sh
+++ b/scripts/sync-runtime.sh
@@ -121,7 +121,9 @@ sync_instance() {
   fi
 
   echo "[sync] quality gate for $name"
-  (cd "$dir" && npm run typecheck && npm test && npm run build)
+  run_runtime_npm "$dir" run typecheck
+  run_runtime_npm "$dir" test
+  run_runtime_npm "$dir" run build
 
   echo "[sync] restarting $name"
   restart_runtime_service "$name"

--- a/tests/backend/runtime-launchd.test.ts
+++ b/tests/backend/runtime-launchd.test.ts
@@ -32,6 +32,35 @@ describe("runtime launchd install", () => {
     expect(plist).not.toContain(path.join(process.cwd(), ".worktrees", "runtime-dev"));
   });
 
+  test("writes the resolved runtime node binary and PATH prefix into launchd plists", async () => {
+    const tempHome = await fs.promises.mkdtemp(path.join(os.tmpdir(), "remux-runtime-node-plist-test-"));
+    tempDirs.push(tempHome);
+
+    const runtimeNodeDir = path.join(tempHome, "toolchains", "node-lts", "bin");
+    const runtimeNodeBin = path.join(runtimeNodeDir, "node");
+    await fs.promises.mkdir(runtimeNodeDir, { recursive: true });
+    await fs.promises.writeFile(runtimeNodeBin, "#!/bin/bash\nexit 0\n", { mode: 0o755 });
+
+    execFileSync("bash", ["scripts/install-launchd.sh"], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        HOME: tempHome,
+        REMUX_RUNTIME_NODE_BIN: runtimeNodeBin
+      },
+      stdio: "pipe"
+    });
+
+    const runtimePlistPath = path.join(tempHome, "Library", "LaunchAgents", "com.remux.dev.plist");
+    const runtimePlist = await fs.promises.readFile(runtimePlistPath, "utf8");
+    expect(runtimePlist).toContain(runtimeNodeBin);
+    expect(runtimePlist).toContain(`${runtimeNodeDir}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin`);
+
+    const syncPlistPath = path.join(tempHome, "Library", "LaunchAgents", "com.remux.runtime-sync.plist");
+    const syncPlist = await fs.promises.readFile(syncPlistPath, "utf8");
+    expect(syncPlist).toContain(`${runtimeNodeDir}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin`);
+  });
+
   test("writes the runtime sync plist against the stable dev runtime worktree", async () => {
     const tempHome = await fs.promises.mkdtemp(path.join(os.tmpdir(), "remux-runtime-sync-plist-test-"));
     tempDirs.push(tempHome);

--- a/tests/backend/runtime-sync-verify.test.ts
+++ b/tests/backend/runtime-sync-verify.test.ts
@@ -33,20 +33,48 @@ describe("runtime sync verification", () => {
     expect(output).not.toContain(process.cwd());
   });
 
+  test("resolves the first executable runtime node from configured candidates", async () => {
+    const tempHome = await fs.promises.mkdtemp(path.join(os.tmpdir(), "remux-runtime-node-resolve-test-"));
+    tempDirs.push(tempHome);
+
+    const runtimeNodeDir = path.join(tempHome, "toolchains", "node-lts", "bin");
+    const runtimeNodeBin = path.join(runtimeNodeDir, "node");
+    const missingNodeBin = path.join(tempHome, "missing", "bin", "node");
+
+    await fs.promises.mkdir(runtimeNodeDir, { recursive: true });
+    await fs.promises.writeFile(runtimeNodeBin, "#!/bin/bash\nexit 0\n", { mode: 0o755 });
+
+    const output = execFileSync("bash", ["-c", "source scripts/runtime-lib.sh && resolve_runtime_node_bin"], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        HOME: tempHome,
+        REMUX_RUNTIME_NODE_SEARCH_PATHS: `${missingNodeBin}:${runtimeNodeBin}`
+      },
+      stdio: "pipe"
+    }).toString("utf8");
+
+    expect(output.trim()).toBe(runtimeNodeBin);
+  });
+
   test("installs runtime dependencies with dev packages even in production-like environments", async () => {
     const tempHome = await fs.promises.mkdtemp(path.join(os.tmpdir(), "remux-runtime-install-test-"));
     tempDirs.push(tempHome);
 
-    const fakeBinDir = path.join(tempHome, "bin");
+    const runtimeNodeDir = path.join(tempHome, "toolchains", "node-lts", "bin");
     const runtimeDir = path.join(tempHome, "runtime-dir");
     const npmLogPath = path.join(tempHome, "npm.log");
-    await fs.promises.mkdir(fakeBinDir, { recursive: true });
+    const runtimeNodeBin = path.join(runtimeNodeDir, "node");
+    const runtimeNpmBin = path.join(runtimeNodeDir, "npm");
+    await fs.promises.mkdir(runtimeNodeDir, { recursive: true });
     await fs.promises.mkdir(runtimeDir, { recursive: true });
+    await fs.promises.writeFile(runtimeNodeBin, "#!/bin/bash\nexit 0\n", { mode: 0o755 });
     await fs.promises.writeFile(
-      path.join(fakeBinDir, "npm"),
+      runtimeNpmBin,
       `#!/bin/bash
 set -euo pipefail
 printf '%s\\n' "$*" >> "${npmLogPath}"
+printf 'node=%s\\n' "$(command -v node)" >> "${npmLogPath}"
 `,
       { mode: 0o755 }
     );
@@ -63,7 +91,7 @@ printf '%s\\n' "$*" >> "${npmLogPath}"
           ...process.env,
           HOME: tempHome,
           NODE_ENV: "production",
-          PATH: `${fakeBinDir}:${process.env.PATH ?? ""}`,
+          REMUX_RUNTIME_NODE_SEARCH_PATHS: runtimeNodeBin,
           TARGET_DIR: runtimeDir
         },
         stdio: "pipe"
@@ -71,6 +99,7 @@ printf '%s\\n' "$*" >> "${npmLogPath}"
     );
 
     await expect(fs.promises.readFile(npmLogPath, "utf8")).resolves.toContain("ci --include=dev");
+    await expect(fs.promises.readFile(npmLogPath, "utf8")).resolves.toContain(`node=${runtimeNodeBin}`);
   });
 
   test("accepts legacy config payloads that only expose version", async () => {


### PR DESCRIPTION
## Summary\n- pin runtime deploys to a stable Node LTS toolchain\n- write resolved Node and PATH into launchd plists\n- run runtime quality gates with the same resolved npm toolchain\n\n## Verification\n- npm run typecheck\n- npm test\n- npm run build\n- actual runtime npm ci via install_runtime_dependencies\n- Deploy Runtime on dev