### PR TITLE
Release dev to main (v0.1.61)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remux",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remux",
-      "version": "0.1.60",
+      "version": "0.1.61",
       "license": "MIT",
       "dependencies": {
         "@microsoft/snapfeed": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remux",
-  "version": "0.1.60",
+  "version": "0.1.61",
   "description": "Remote workspace cockpit for terminal-first work, with tmux, zellij, and conpty backends",
   "license": "MIT",
   "repository": {

--- a/tests/e2e/app.chrome.spec.ts
+++ b/tests/e2e/app.chrome.spec.ts
@@ -320,10 +320,13 @@ test.describe("remux browser behavior", () => {
         await expect(addSnippet).toBeVisible();
         await expect(backendButton).toBeVisible();
 
+        const minimumTouchTargetSize = 44;
+        // Chromium can report 44px controls as 43.99999 because of subpixel rounding.
+        const touchTargetEpsilon = 0.1;
         const minimumTouchTarget = async (locator: Locator): Promise<void> => {
           const box = await locator.boundingBox();
-          expect(box?.width ?? 0).toBeGreaterThanOrEqual(44);
-          expect(box?.height ?? 0).toBeGreaterThanOrEqual(44);
+          expect((box?.width ?? 0) + touchTargetEpsilon).toBeGreaterThanOrEqual(minimumTouchTargetSize);
+          expect((box?.height ?? 0) + touchTargetEpsilon).toBeGreaterThanOrEqual(minimumTouchTargetSize);
         };
 
         await minimumTouchTarget(sessionClose);


### PR DESCRIPTION
## Summary\n- allow a tiny subpixel tolerance for 44px touch-target assertions\n- keep the mobile drawer E2E from failing on Chromium 43.99999px rounding\n\n## Verification\n- npm run typecheck\n- npm test\n- npm run build\n- npm run test:e2e\n- Deploy Runtime on dev