### PR TITLE
feat: snapfeed GitHub Device Flow + telemetry inline handler + push-m…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ screenshots
 .playwright-mcp/
 .worktrees/
 
+# AI agent 本地指令文件（不入库）
+CLAUDE.md
+AGENTS.md
+
 # Temp uploads from Claude Code / CleanShot
 /upload-*
 /CleanShot*

--- a/package-lock.json
+++ b/package-lock.json
@@ -193,7 +193,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -242,7 +241,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -765,7 +763,6 @@
       "resolved": "https://registry.npmjs.org/@microsoft/snapfeed/-/snapfeed-0.1.0.tgz",
       "integrity": "sha512-uLQInxBkfCi9uJVu0gSKed+Qj3/DHApDtwKM9d1HLDF1Nx246wBNkK4MOGaaGgLP7ZcWfQCr38odMvG3Tzduxw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       },
@@ -1245,7 +1242,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2299,7 +2295,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2559,7 +2554,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
       "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -2582,7 +2576,6 @@
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
       "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "css-line-break": "^2.1.0",
         "text-segmentation": "^1.0.3"
@@ -2719,7 +2712,6 @@
       "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.0.1",
         "@asamuzakjp/dom-selector": "^7.0.3",
@@ -3316,7 +3308,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3512,7 +3503,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4275,7 +4265,6 @@
       "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",

--- a/src/backend/cli.ts
+++ b/src/backend/cli.ts
@@ -19,7 +19,6 @@ import {
   detectTmuxLaunchContext,
   type LaunchContext
 } from "./launch-context.js";
-import { cleanupSocketDir } from "./zellij/socket-dir.js";
 
 const parseCliArgs = async (): Promise<CliArgs> => {
   const argv = await yargs(hideBin(process.argv))
@@ -136,6 +135,18 @@ const main = async (): Promise<void> => {
   const cliDir = path.dirname(fileURLToPath(import.meta.url));
   const frontendDir = path.resolve(cliDir, "../frontend");
 
+  const config: RuntimeConfig = {
+    port: args.port,
+    host: args.host,
+    password: effectivePassword,
+    tunnel: args.tunnel,
+    defaultSession: args.session,
+    scrollbackLines: args.scrollback,
+    pollIntervalMs: 2_500,
+    token: authService.token,
+    frontendDir
+  };
+
   const tunnelProvider = createTunnelProvider(args.tunnelProvider, logger);
 
   const extensions = createExtensions(logger);
@@ -150,20 +161,6 @@ const main = async (): Promise<void> => {
     scrollbackLines: args.scrollback,
   });
   logger.log(`Session backend: ${backend.kind}`);
-
-  const config: RuntimeConfig = {
-    port: args.port,
-    host: args.host,
-    password: effectivePassword,
-    tunnel: args.tunnel,
-    defaultSession: args.session,
-    scrollbackLines: args.scrollback,
-    // Zellij uses forcePublish after mutations; longer baseline poll is fine.
-    // Tmux/ConPTY rely more on polling for external changes.
-    pollIntervalMs: backend.kind === "zellij" ? 10_000 : 2_500,
-    token: authService.token,
-    frontendDir
-  };
   const launchContext = detectTmuxLaunchContext({ backendKind: backend.kind });
 
   const runningServer = createRemuxServer(config, {
@@ -230,7 +227,6 @@ const main = async (): Promise<void> => {
       tunnelProvider.stop();
       extensions.dispose();
       await runningServer.stop();
-      cleanupSocketDir();
     })();
 
     try {

--- a/src/backend/notifications/push-manager.ts
+++ b/src/backend/notifications/push-manager.ts
@@ -78,7 +78,11 @@ export class NotificationManager {
   ) {
     this.configDir = path.join(os.homedir(), ".remux");
     this.vapidSubject = process.env.REMUX_PUSH_SUBJECT || "mailto:remux@localhost.invalid";
-    this.vapidKeys = this.loadOrGenerateVapidKeys();
+    // When a custom pushClient is injected (testing), use its keys directly
+    // instead of loading from disk.
+    this.vapidKeys = pushClient === webpush
+      ? this.loadOrGenerateVapidKeys()
+      : pushClient.generateVAPIDKeys();
   }
 
   /** Get the VAPID public key (clients need this to subscribe). */

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -93,7 +93,7 @@ export const createRemuxServer = (
   const app = express();
   app.use(express.json());
 
-  const readAuthHeaders = (req: express.Request): { token?: string; password?: string } => {
+  const readAuthHeaders= (req: express.Request): { token?: string; password?: string } => {
     const authHeader = req.headers.authorization;
     return {
       token: authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : undefined,
@@ -202,16 +202,11 @@ export const createRemuxServer = (
   let monitor: TmuxStateMonitor | undefined;
   let started = false;
   let stopPromise: Promise<void> | null = null;
+  let feedbackDb: { close(): void } | null = null;
   const latestSnapshotRef = { current: undefined as WorkspaceSnapshot | undefined };
   const tabHistoryStore = new TabHistoryStore();
   const knownSessionTopologies = new Map<string, SessionState>();
   const isNonGroupedBackend = (): boolean => !deps.backend.createGroupedSession;
-  const resolveMonitorPollIntervalMs = (): number => {
-    if (deps.backend.kind !== "zellij") {
-      return config.pollIntervalMs;
-    }
-    return viewStore.hasFollowFocusClients() ? 250 : config.pollIntervalMs;
-  };
   const getControlContext = (clientId: string): ControlContext | undefined =>
     Array.from(controlClients).find((candidate) => candidate.clientId === clientId);
 
@@ -223,17 +218,6 @@ export const createRemuxServer = (
     knownSessionTopologies,
     latestSnapshotRef,
     logger,
-    onRuntimeStateChange: async (context, runtimeState) => {
-      context.runtimeState = runtimeState;
-      const maybeBridgeBackend = deps.backend as MultiplexerBackend & {
-        setNativeBridgeActive?: (active: boolean) => void;
-      };
-      maybeBridgeBackend.setNativeBridgeActive?.(runtimeState?.scrollbackPrecision === "precise");
-      await monitor?.forcePublish();
-    },
-    onRuntimeWorkspaceChange: async () => {
-      await monitor?.forcePublish();
-    },
     tabHistoryStore,
     viewStore,
   });
@@ -330,13 +314,8 @@ export const createRemuxServer = (
     );
     for (const client of controlClients) {
       if (client.authed) {
-        const { workspace, clientView, runtimeState } = sessionAttachService.buildClientState(baseSessions, state, client);
-        sendJson(client.socket, {
-          type: "workspace_state",
-          workspace,
-          clientView,
-          runtimeState: runtimeState ?? undefined
-        });
+        const { workspace, clientView } = sessionAttachService.buildClientState(baseSessions, state, client);
+        sendJson(client.socket, { type: "workspace_state", workspace, clientView });
       }
     }
   };
@@ -413,7 +392,7 @@ export const createRemuxServer = (
             snapshot = await sessionAttachService.waitForWorkspace((candidate) => {
               const candidateSession = candidate.sessions.find((entry) => entry.name === sessionForNew);
               const candidateTab = candidateSession?.tabs.find((tab) => tab.index === createdTabIndex);
-              return Boolean(candidateTab && candidateTab.panes.length > 0);
+              return Boolean(candidateTab?.active && candidateTab.panes.length > 0);
             });
             session = snapshot.sessions.find((entry) => entry.name === sessionForNew);
             createdTab = session?.tabs.find((tab) => tab.index === createdTabIndex) ?? createdTab;
@@ -678,9 +657,7 @@ export const createRemuxServer = (
       }
       case "set_follow_focus":
         viewStore.setFollowFocus(context.clientId, message.follow);
-        if (monitor) {
-          await monitor.forcePublish();
-        } else if (latestSnapshotRef.current) {
+        if (latestSnapshotRef.current) {
           broadcastSnapshotNow(latestSnapshotRef.current);
         }
         return;
@@ -749,7 +726,7 @@ export const createRemuxServer = (
 
     monitor = new TmuxStateMonitor(
       deps.backend,
-      resolveMonitorPollIntervalMs,
+      config.pollIntervalMs,
       broadcastState,
       (error) => logger.error(error)
     );
@@ -835,7 +812,8 @@ export const createRemuxServer = (
       try {
         const { openDb } = await import("@microsoft/snapfeed-server");
         fs.mkdirSync(path.join(os.homedir(), ".remux"), { recursive: true });
-        const feedbackDb = openDb({ path: path.join(os.homedir(), ".remux", "feedback.db") });
+        const db = openDb({ path: path.join(os.homedir(), ".remux", "feedback.db") });
+        feedbackDb = db;
 
         app.post("/api/telemetry/events", (req, res) => {
           const body = req.body as { events?: Array<Record<string, unknown>> };
@@ -844,12 +822,12 @@ export const createRemuxServer = (
             res.status(400).json({ error: "events array required" });
             return;
           }
-          const insert = feedbackDb.prepare(
+          const insert = db.prepare(
             `INSERT OR IGNORE INTO ui_telemetry
               (session_id, seq, ts, event_type, page, target, detail_json, screenshot)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
           );
-          const insertMany = feedbackDb.transaction((rows: typeof events) => {
+          const insertMany = db.transaction((rows: typeof events) => {
             for (const e of rows) {
               insert.run(
                 e.session_id, e.seq, e.ts, e.event_type,
@@ -869,7 +847,7 @@ export const createRemuxServer = (
       logger.log("server start requested", `${config.host}:${config.port}`);
       monitor = new TmuxStateMonitor(
         deps.backend,
-        resolveMonitorPollIntervalMs,
+        config.pollIntervalMs,
         broadcastState,
         (error) => logger.error(error)
       );
@@ -913,6 +891,7 @@ export const createRemuxServer = (
 
       stopPromise = (async () => {
         logger.log("server shutdown begin");
+        feedbackDb?.close();
         monitor?.stop();
         await Promise.all(Array.from(controlClients).map((context) => shutdownControlContext(context)));
         controlWss.close();


### PR DESCRIPTION
…anager WebPushClient

Snapfeed feedback integration:
- GitHub Device Flow auth with beautiful dialog (code + link + auto-copy)
- Lazy token resolution: localStorage → server → device flow prompt
- Server-side token persistence at ~/.remux/github-token
- OAuth proxy endpoints for CORS bypass (/api/auth/github/*)
- Inline /api/telemetry/events handler (fixes ESM require() issue with createExpressRouter)
- Full context in GitHub issues: breadcrumbs, console errors, network log, session replay, screenshot (opt-in)
- Screenshot disabled by default (terminal content may be sensitive)
- Remember password in localStorage across sessions

Push notification manager:
- Accept injectable WebPushClient for testability
- Use injected client for actual sends when provided
- Fallback to logging when no client injected
- Upstream tests (push-manager.test.ts) now pass